### PR TITLE
feat: Supabase auth foundation — first PR (Issue #6)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,17 @@
 # OpenAI API Key (required for prompt generation)
 OPENAI_API_KEY=
+
+# Supabase — provision a project at https://supabase.com/dashboard, then
+# copy this file to `.env.local` and fill in the values from
+# Project Settings → API. `.env.local` is gitignored.
+#
+# Browser-exposed vars must be prefixed with VITE_ so Vite inlines them into
+# the client bundle. These are safe to expose: the publishable key is
+# protected by Row-Level Security policies on the database.
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_PUBLISHABLE_KEY=sb_publishable_your_key_here
+
+# Server-only — used by Vercel serverless functions under /api. NEVER prefix
+# with VITE_ (would leak to the browser). Only needed for admin operations
+# that bypass RLS; leave unset for the current auth-only feature set.
+# SUPABASE_SERVICE_ROLE_KEY=your_service_role_key_here

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",
         "@google/generative-ai": "^0.24.1",
+        "@supabase/supabase-js": "^2.103.0",
         "openai": "^6.21.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -161,7 +162,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -510,7 +510,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -551,7 +550,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1648,6 +1646,92 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.103.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.103.0.tgz",
+      "integrity": "sha512-6zAanO6c+6gpHOlt5Lb9TlBBkJdZiUWkWCJKAxzkywBDcwaHlLJKXnjQGX6GyVCyKRR1e7sTq4re/yRTH6U/9A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.103.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.103.0.tgz",
+      "integrity": "sha512-YrneV2NjskUkkmkZ2Jt2n3elBgbWzV4Y1M9MM370z2Zd5ZPFqFbY8KIoPwuNjtAGE9YrpKBxnbZqeF07BiN9Og==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
+      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.103.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.103.0.tgz",
+      "integrity": "sha512-rC3sRxYdPZymkp2CZR1MiNQgbOleD01bGsW8VxEKRR5nMkLZ1NgAS1QTQf78Wh30czFyk505ZYr9Od8/mWT2TA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.103.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.103.0.tgz",
+      "integrity": "sha512-gcPtXzZ6izyyBVf2of7K3dEt8CScPJn8VcSlQq6oWL9QoE1kqfQl0oFrOMHd5qrcADewxI7OxxosLB8W4XqtIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.0",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.103.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.103.0.tgz",
+      "integrity": "sha512-DHmlvdAXwtOmZNbkIZi4lkobPR3XjIzoOgzoz5duMf6G+sDeY015YrzMJCnqdccuYr7X5x4yYuSwF//RoN2dvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.103.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.103.0.tgz",
+      "integrity": "sha512-j/6q5+LtXbR/YOLSLhy7Na74RD1cV2v+KwIIuuqMEjk1JpLEEyu0ynwDHpGoxMncDQl+R5FogaVqZm+85lZvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.103.0",
+        "@supabase/functions-js": "2.103.0",
+        "@supabase/postgrest-js": "2.103.0",
+        "@supabase/realtime-js": "2.103.0",
+        "@supabase/storage-js": "2.103.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -1743,7 +1827,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1826,9 +1911,7 @@
       "version": "24.10.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.13.tgz",
       "integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1839,7 +1922,6 @@
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1850,9 +1932,17 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1900,7 +1990,6 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -2263,7 +2352,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2314,6 +2402,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2419,7 +2508,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2656,7 +2744,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.286",
@@ -2756,7 +2845,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3180,6 +3268,15 @@
         "node": ">= 14"
       }
     },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3290,7 +3387,6 @@
       "integrity": "sha512-KDYJgZ6T2TKdU8yBfYueq5EPG/EylMsBvCaenWMJb2OXmjgczzwveRCoJ+Hgj1lXPDyasvrgneSn4GBuR1hYyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -3448,6 +3544,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3680,7 +3777,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3749,6 +3845,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3764,6 +3861,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3786,7 +3884,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3796,7 +3893,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3809,7 +3905,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -4148,6 +4245,12 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4167,7 +4270,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4214,7 +4316,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -4264,7 +4365,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4503,6 +4603,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -4545,7 +4666,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.82.0",
     "@google/generative-ai": "^0.24.1",
+    "@supabase/supabase-js": "^2.103.0",
     "openai": "^6.21.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { useFeedbackStore } from './stores/feedbackStore';
 import { useNavigationStore } from './stores/navigationStore';
 import { useHistoryStore } from './stores/historyStore';
 import { usePreferencesStore } from './stores/preferencesStore';
+import { useAuthStore } from './stores/authStore';
 import { useStream } from './hooks/useStream';
 import { PromptInput, PlatformSelector } from './features/PromptInput';
 import {
@@ -15,6 +16,7 @@ import {
 } from './features/Generation';
 import { FeedbackWidget } from './features/Feedback';
 import { SettingsModal } from './features/Settings';
+import { AuthModal } from './features/Auth';
 import { TemplatesPage } from './features/Templates';
 import { LibraryPage } from './features/Library';
 import { Button, Spinner, ErrorBoundary, Sidebar } from './components';
@@ -151,11 +153,17 @@ function GeneratePage() {
 function App() {
   const currentPage = useNavigationStore((s) => s.currentPage);
   const toggleSidebar = useNavigationStore((s) => s.toggleSidebar);
+  const initializeAuth = useAuthStore((s) => s.initialize);
+
+  useEffect(() => {
+    void initializeAuth();
+  }, [initializeAuth]);
 
   return (
     <ErrorBoundary>
       <Toaster position="top-center" duration={5000} closeButton />
       <SettingsModal />
+      <AuthModal />
       <a href="#main-content" className="skip-link">
         Skip to content
       </a>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { useNavigationStore } from '../../stores/navigationStore';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { useThemeStore } from '../../stores/themeStore';
+import { useAuthStore } from '../../stores/authStore';
 import type { Page } from '../../stores/navigationStore';
 import styles from './Sidebar.module.css';
 
@@ -24,6 +25,8 @@ export function Sidebar() {
   const openSettings = useSettingsStore((s) => s.openSettings);
   const theme = useThemeStore((s) => s.theme);
   const toggleTheme = useThemeStore((s) => s.toggleTheme);
+  const user = useAuthStore((s) => s.user);
+  const openAuthModal = useAuthStore((s) => s.openAuthModal);
 
   return (
     <>
@@ -80,6 +83,16 @@ export function Sidebar() {
           >
             <span className={styles.actionGlyph}>◎</span>
             <span className={styles.actionLabel}>Settings</span>
+          </button>
+          <button
+            className={styles.actionButton}
+            onClick={() => openAuthModal()}
+            aria-label={user ? 'Account' : 'Sign in'}
+          >
+            <span className={styles.actionGlyph}>●</span>
+            <span className={styles.actionLabel}>
+              {user ? 'Account' : 'Sign in'}
+            </span>
           </button>
         </div>
 

--- a/src/features/Auth/AuthModal.module.css
+++ b/src/features/Auth/AuthModal.module.css
@@ -1,0 +1,301 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(26, 22, 18, 0.4);
+  backdrop-filter: blur(6px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: var(--space-md);
+  animation: fadeIn var(--transition-normal);
+}
+
+[data-theme='dark'] .overlay {
+  background: rgba(0, 0, 0, 0.6);
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.modal {
+  position: relative;
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius-md);
+  width: 100%;
+  max-width: 28rem;
+  max-height: 90vh;
+  overflow-y: auto;
+  padding: var(--space-2xl);
+  box-shadow: var(--shadow-lg);
+  animation: slideUp var(--transition-normal);
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.closeButton {
+  position: absolute;
+  top: var(--space-md);
+  right: var(--space-md);
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: var(--ink-muted);
+  font-size: 1.5rem;
+  cursor: pointer;
+  transition: color var(--transition-fast);
+}
+
+.closeButton:hover {
+  color: var(--ink);
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75em;
+  font-family: var(--font-body);
+  font-size: var(--font-size-eyebrow);
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+  margin-bottom: var(--space-sm);
+}
+
+.eyebrowRule {
+  display: inline-block;
+  width: 2rem;
+  height: 1px;
+  background: var(--ink-muted);
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  font-weight: 500;
+  color: var(--ink);
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  padding-right: var(--space-2xl);
+}
+
+.title em {
+  font-style: italic;
+  font-weight: 500;
+  color: var(--accent);
+}
+
+.divider {
+  border: 0;
+  border-top: 1px solid var(--rule);
+  margin: var(--space-lg) 0;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.fieldLabel {
+  font-family: var(--font-body);
+  font-size: var(--font-size-eyebrow);
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+}
+
+.input {
+  padding: var(--space-sm) var(--space-md);
+  background: var(--paper-raised);
+  border: 1px solid var(--rule-strong);
+  border-radius: var(--radius-md);
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  transition:
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast),
+    background var(--transition-fast);
+}
+
+.input:hover {
+  border-color: var(--ink-faint);
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--accent);
+  background: var(--paper);
+  box-shadow: 0 0 0 3px var(--accent-faint);
+}
+
+.input::placeholder {
+  color: var(--ink-faint);
+}
+
+.googleButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  background: var(--paper-raised);
+  border: 1px solid var(--rule-strong);
+  border-radius: var(--radius-md);
+  color: var(--ink);
+  font-family: var(--font-body);
+  font-size: 0.9375rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    border-color var(--transition-fast),
+    background var(--transition-fast);
+}
+
+.googleButton:hover:not(:disabled) {
+  border-color: var(--accent);
+  background: var(--paper);
+}
+
+.googleButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.separator {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  margin: var(--space-md) 0;
+  color: var(--ink-muted);
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 0.8125rem;
+}
+
+.separatorLine {
+  flex: 1;
+  height: 1px;
+  background: var(--rule);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-sm);
+  margin-top: var(--space-md);
+}
+
+.toggleRow {
+  display: flex;
+  justify-content: center;
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 0.875rem;
+  color: var(--ink-muted);
+  margin-top: var(--space-md);
+}
+
+.toggleLink {
+  background: none;
+  border: none;
+  border-bottom: 1px dashed var(--rule-strong);
+  color: var(--accent);
+  font-family: inherit;
+  font-size: inherit;
+  font-style: inherit;
+  cursor: pointer;
+  padding: 0 2px;
+  margin-left: 0.4em;
+  transition:
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.toggleLink:hover {
+  color: var(--ink);
+  border-bottom-color: var(--ink);
+}
+
+.error {
+  padding: var(--space-sm) var(--space-md);
+  background: var(--error-faint, rgba(180, 50, 40, 0.08));
+  border: 1px solid var(--error, #b43228);
+  border-radius: var(--radius-sm);
+  color: var(--error, #b43228);
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  line-height: 1.5;
+}
+
+.notConfigured {
+  padding: var(--space-md);
+  border: 1px dashed var(--rule-strong);
+  border-radius: var(--radius-sm);
+  color: var(--ink-muted);
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  line-height: 1.5;
+}
+
+.notConfigured code {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  background: var(--paper-raised);
+  padding: 2px 6px;
+  border-radius: 3px;
+  border: 1px solid var(--rule);
+}
+
+.profileCard {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  background: var(--paper-raised);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius-md);
+}
+
+.profileEmail {
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  color: var(--ink);
+  word-break: break-all;
+}
+
+.profileHint {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 0.8125rem;
+  color: var(--ink-muted);
+}

--- a/src/features/Auth/AuthModal.tsx
+++ b/src/features/Auth/AuthModal.tsx
@@ -1,0 +1,248 @@
+import { useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { useAuthStore } from '../../stores/authStore';
+import { Button } from '../../components';
+import styles from './AuthModal.module.css';
+
+function GoogleIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" aria-hidden="true">
+      <path
+        fill="#4285F4"
+        d="M17.64 9.205c0-.639-.057-1.252-.164-1.841H9v3.481h4.844a4.14 4.14 0 0 1-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.874 2.684-6.615z"
+      />
+      <path
+        fill="#34A853"
+        d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M3.964 10.71A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 0 0 0 9c0 1.452.348 2.827.957 4.042l3.007-2.332z"
+      />
+      <path
+        fill="#EA4335"
+        d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z"
+      />
+    </svg>
+  );
+}
+
+export function AuthModal() {
+  const showAuthModal = useAuthStore((s) => s.showAuthModal);
+  const closeAuthModal = useAuthStore((s) => s.closeAuthModal);
+  const authView = useAuthStore((s) => s.authView);
+  const setAuthView = useAuthStore((s) => s.setAuthView);
+  const user = useAuthStore((s) => s.user);
+  const isConfigured = useAuthStore((s) => s.isConfigured);
+  const error = useAuthStore((s) => s.error);
+  const isLoading = useAuthStore((s) => s.isLoading);
+  const signInWithGoogle = useAuthStore((s) => s.signInWithGoogle);
+  const signInWithEmail = useAuthStore((s) => s.signInWithEmail);
+  const signUpWithEmail = useAuthStore((s) => s.signUpWithEmail);
+  const signOut = useAuthStore((s) => s.signOut);
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const emailInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (showAuthModal && !user) {
+      setTimeout(() => emailInputRef.current?.focus(), 50);
+    }
+  }, [showAuthModal, user]);
+
+  useEffect(() => {
+    if (!showAuthModal) return;
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeAuthModal();
+    };
+    document.addEventListener('keydown', handleEsc);
+    return () => document.removeEventListener('keydown', handleEsc);
+  }, [showAuthModal, closeAuthModal]);
+
+  if (!showAuthModal) return null;
+
+  const handleEmailSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!email.trim() || !password) return;
+    if (authView === 'sign-in') {
+      void signInWithEmail(email.trim(), password);
+    } else {
+      void signUpWithEmail(email.trim(), password);
+    }
+  };
+
+  const handleSignOut = async () => {
+    await signOut();
+    toast.success('Signed out.');
+    closeAuthModal();
+  };
+
+  const isSignedIn = Boolean(user);
+  const title = isSignedIn
+    ? 'Your account.'
+    : authView === 'sign-in'
+      ? 'Welcome back.'
+      : 'Create an account.';
+  const eyebrow = isSignedIn
+    ? 'Account'
+    : authView === 'sign-in'
+      ? 'Sign in'
+      : 'Sign up';
+
+  return (
+    <div className={styles.overlay} onClick={closeAuthModal}>
+      <div
+        className={styles.modal}
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label={isSignedIn ? 'Account' : 'Sign in'}
+      >
+        <button
+          className={styles.closeButton}
+          onClick={closeAuthModal}
+          aria-label="Close"
+        >
+          &times;
+        </button>
+
+        <div className={styles.eyebrow}>
+          <span className={styles.eyebrowRule} />
+          <span>{eyebrow}</span>
+        </div>
+        <h2 className={styles.title}>
+          {title.split(' ').slice(0, -1).join(' ')}{' '}
+          <em>{title.split(' ').slice(-1)[0]}</em>
+        </h2>
+
+        <hr className={styles.divider} />
+
+        {!isConfigured && (
+          <div className={styles.notConfigured}>
+            Sign-in is unavailable because Supabase is not configured. Copy
+            <code>.env.example</code> to <code>.env.local</code> and add your{' '}
+            <code>VITE_SUPABASE_URL</code> and{' '}
+            <code>VITE_SUPABASE_PUBLISHABLE_KEY</code>, then restart the dev
+            server.
+          </div>
+        )}
+
+        {isConfigured && isSignedIn && user && (
+          <>
+            <div className={styles.profileCard}>
+              <span className={styles.fieldLabel}>Signed in as</span>
+              <span className={styles.profileEmail}>{user.email}</span>
+              <span className={styles.profileHint}>
+                Cloud sync for history and preferences is coming next.
+              </span>
+            </div>
+            <div className={styles.actions}>
+              <Button variant="secondary" onClick={closeAuthModal}>
+                Close
+              </Button>
+              <Button onClick={handleSignOut}>Sign out</Button>
+            </div>
+          </>
+        )}
+
+        {isConfigured && !isSignedIn && (
+          <>
+            <button
+              type="button"
+              className={styles.googleButton}
+              onClick={() => void signInWithGoogle()}
+              disabled={isLoading}
+            >
+              <GoogleIcon />
+              Continue with Google
+            </button>
+
+            <div className={styles.separator}>
+              <span className={styles.separatorLine} />
+              <span>or</span>
+              <span className={styles.separatorLine} />
+            </div>
+
+            <form className={styles.form} onSubmit={handleEmailSubmit}>
+              <div className={styles.field}>
+                <label className={styles.fieldLabel} htmlFor="auth-email">
+                  Email
+                </label>
+                <input
+                  ref={emailInputRef}
+                  id="auth-email"
+                  type="email"
+                  className={styles.input}
+                  placeholder="you@example.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  autoComplete="email"
+                  required
+                />
+              </div>
+              <div className={styles.field}>
+                <label className={styles.fieldLabel} htmlFor="auth-password">
+                  Password
+                </label>
+                <input
+                  id="auth-password"
+                  type="password"
+                  className={styles.input}
+                  placeholder="••••••••"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  autoComplete={
+                    authView === 'sign-in' ? 'current-password' : 'new-password'
+                  }
+                  minLength={6}
+                  required
+                />
+              </div>
+
+              {error && <div className={styles.error}>{error}</div>}
+
+              <div className={styles.actions}>
+                <Button variant="secondary" type="button" onClick={closeAuthModal}>
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  disabled={isLoading || !email.trim() || !password}
+                >
+                  {authView === 'sign-in' ? 'Sign in' : 'Create account'}
+                </Button>
+              </div>
+            </form>
+
+            <div className={styles.toggleRow}>
+              {authView === 'sign-in' ? (
+                <>
+                  Don&rsquo;t have an account?
+                  <button
+                    type="button"
+                    className={styles.toggleLink}
+                    onClick={() => setAuthView('sign-up')}
+                  >
+                    Sign up
+                  </button>
+                </>
+              ) : (
+                <>
+                  Already have an account?
+                  <button
+                    type="button"
+                    className={styles.toggleLink}
+                    onClick={() => setAuthView('sign-in')}
+                  >
+                    Sign in
+                  </button>
+                </>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/Auth/index.ts
+++ b/src/features/Auth/index.ts
@@ -1,0 +1,1 @@
+export { AuthModal } from './AuthModal';

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,27 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+const url = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const key = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY as string | undefined;
+
+/**
+ * Whether the browser has valid Supabase credentials configured. Every UI
+ * surface that calls Supabase should gate on this flag so the app degrades
+ * gracefully when env vars are missing (e.g. local dev without .env.local).
+ */
+export const isSupabaseConfigured = Boolean(url && key);
+
+// Placeholder URL/key prevent a module-load crash when env vars are missing.
+// All real usage is gated behind `isSupabaseConfigured` — requests against
+// the placeholder would fail, but we never reach them.
+export const supabase: SupabaseClient = createClient(
+  url ?? 'https://placeholder.supabase.co',
+  key ?? 'placeholder',
+  {
+    auth: {
+      persistSession: true,
+      autoRefreshToken: true,
+      detectSessionInUrl: true,
+      storageKey: 'promptbuilder-auth',
+    },
+  },
+);

--- a/src/stores/authStore.test.ts
+++ b/src/stores/authStore.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useAuthStore } from './authStore';
+
+describe('authStore', () => {
+  beforeEach(() => {
+    // Reset modal + view between tests. We don't reset session/user because
+    // initialize() is async and touches Supabase; those are covered elsewhere.
+    useAuthStore.setState({
+      showAuthModal: false,
+      authView: 'sign-in',
+      error: null,
+    });
+  });
+
+  it('has sensible defaults', () => {
+    const state = useAuthStore.getState();
+    expect(state.showAuthModal).toBe(false);
+    expect(state.authView).toBe('sign-in');
+    expect(state.error).toBeNull();
+    // session/user start null until initialize() runs
+    expect(state.session).toBeNull();
+    expect(state.user).toBeNull();
+  });
+
+  it('openAuthModal opens the modal in sign-in view by default', () => {
+    useAuthStore.getState().openAuthModal();
+    const state = useAuthStore.getState();
+    expect(state.showAuthModal).toBe(true);
+    expect(state.authView).toBe('sign-in');
+  });
+
+  it('openAuthModal accepts an explicit view', () => {
+    useAuthStore.getState().openAuthModal('sign-up');
+    expect(useAuthStore.getState().authView).toBe('sign-up');
+  });
+
+  it('closeAuthModal hides the modal and clears the error', () => {
+    useAuthStore.setState({ showAuthModal: true, error: 'boom' });
+    useAuthStore.getState().closeAuthModal();
+    const state = useAuthStore.getState();
+    expect(state.showAuthModal).toBe(false);
+    expect(state.error).toBeNull();
+  });
+
+  it('setAuthView toggles between sign-in and sign-up', () => {
+    useAuthStore.getState().setAuthView('sign-up');
+    expect(useAuthStore.getState().authView).toBe('sign-up');
+    useAuthStore.getState().setAuthView('sign-in');
+    expect(useAuthStore.getState().authView).toBe('sign-in');
+  });
+
+  it('clearError resets the error message', () => {
+    useAuthStore.setState({ error: 'bad password' });
+    useAuthStore.getState().clearError();
+    expect(useAuthStore.getState().error).toBeNull();
+  });
+
+  it('short-circuits auth calls when Supabase is not configured', async () => {
+    // In test env VITE_SUPABASE_* is unset, so isConfigured is false.
+    expect(useAuthStore.getState().isConfigured).toBe(false);
+
+    await useAuthStore.getState().signInWithGoogle();
+    expect(useAuthStore.getState().error).toMatch(/not configured/i);
+
+    useAuthStore.getState().clearError();
+    await useAuthStore.getState().signInWithEmail('a@b.co', 'password');
+    expect(useAuthStore.getState().error).toMatch(/not configured/i);
+
+    useAuthStore.getState().clearError();
+    await useAuthStore.getState().signUpWithEmail('a@b.co', 'password');
+    expect(useAuthStore.getState().error).toMatch(/not configured/i);
+  });
+
+  it('initialize sets isLoading=false even when unconfigured', async () => {
+    useAuthStore.setState({ isLoading: true });
+    await useAuthStore.getState().initialize();
+    expect(useAuthStore.getState().isLoading).toBe(false);
+  });
+});

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,0 +1,122 @@
+import { create } from 'zustand';
+import type { Session, User } from '@supabase/supabase-js';
+import { supabase, isSupabaseConfigured } from '../lib/supabase';
+
+export type AuthView = 'sign-in' | 'sign-up';
+
+interface AuthState {
+  session: Session | null;
+  user: User | null;
+  isLoading: boolean;
+  isConfigured: boolean;
+  showAuthModal: boolean;
+  authView: AuthView;
+  error: string | null;
+
+  initialize: () => Promise<void>;
+  signInWithGoogle: () => Promise<void>;
+  signInWithEmail: (email: string, password: string) => Promise<void>;
+  signUpWithEmail: (email: string, password: string) => Promise<void>;
+  signOut: () => Promise<void>;
+  openAuthModal: (view?: AuthView) => void;
+  closeAuthModal: () => void;
+  setAuthView: (view: AuthView) => void;
+  clearError: () => void;
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  session: null,
+  user: null,
+  // Start in loading state only when we actually intend to fetch a session.
+  isLoading: isSupabaseConfigured,
+  isConfigured: isSupabaseConfigured,
+  showAuthModal: false,
+  authView: 'sign-in',
+  error: null,
+
+  initialize: async () => {
+    if (!isSupabaseConfigured) {
+      set({ isLoading: false });
+      return;
+    }
+
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+    set({
+      session,
+      user: session?.user ?? null,
+      isLoading: false,
+    });
+
+    supabase.auth.onAuthStateChange((_event, nextSession) => {
+      set({
+        session: nextSession,
+        user: nextSession?.user ?? null,
+      });
+    });
+  },
+
+  signInWithGoogle: async () => {
+    if (!isSupabaseConfigured) {
+      set({ error: 'Sign-in is unavailable — Supabase is not configured.' });
+      return;
+    }
+    set({ error: null });
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: `${window.location.origin}${window.location.pathname}`,
+      },
+    });
+    if (error) set({ error: error.message });
+  },
+
+  signInWithEmail: async (email, password) => {
+    if (!isSupabaseConfigured) {
+      set({ error: 'Sign-in is unavailable — Supabase is not configured.' });
+      return;
+    }
+    set({ error: null, isLoading: true });
+    const { error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+    if (error) {
+      set({ error: error.message, isLoading: false });
+      return;
+    }
+    set({ isLoading: false, showAuthModal: false });
+  },
+
+  signUpWithEmail: async (email, password) => {
+    if (!isSupabaseConfigured) {
+      set({ error: 'Sign-up is unavailable — Supabase is not configured.' });
+      return;
+    }
+    set({ error: null, isLoading: true });
+    const { error } = await supabase.auth.signUp({ email, password });
+    if (error) {
+      set({ error: error.message, isLoading: false });
+      return;
+    }
+    // When email confirmation is enabled, the user won't be signed in yet —
+    // keep the modal open with a hint.
+    set({
+      isLoading: false,
+      error: 'Check your email to confirm your account before signing in.',
+    });
+  },
+
+  signOut: async () => {
+    if (!isSupabaseConfigured) return;
+    await supabase.auth.signOut();
+    set({ session: null, user: null });
+  },
+
+  openAuthModal: (view = 'sign-in') =>
+    set({ showAuthModal: true, authView: view, error: null }),
+  closeAuthModal: () => set({ showAuthModal: false, error: null }),
+  setAuthView: (view) => set({ authView: view, error: null }),
+  clearError: () => set({ error: null }),
+}));

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -27,3 +27,5 @@ export {
   INSTRUCTION_SUFFIX_MAX_LENGTH,
 } from './preferencesStore';
 export type { ClarificationMode, PreferencesState } from './preferencesStore';
+export { useAuthStore } from './authStore';
+export type { AuthView } from './authStore';

--- a/supabase/migrations/0001_init.sql
+++ b/supabase/migrations/0001_init.sql
@@ -1,0 +1,152 @@
+-- PromptBuilder — initial schema for Issue #6 (User Accounts & Auth)
+--
+-- Run this once against your Supabase project via the SQL Editor:
+--   Supabase Dashboard → SQL Editor → New query → paste → Run
+--
+-- Creates four tables keyed to auth.users:
+--   profiles    — minimal user profile (one row per user)
+--   preferences — mirrors the client-side preferencesStore shape
+--   history     — mirrors the client-side historyStore shape
+--   feedback    — mirrors the client-side feedbackStore shape
+--
+-- Every table is protected by Row-Level Security so users can only read
+-- and write their own rows. A trigger on auth.users auto-creates a
+-- profiles row on signup.
+
+create extension if not exists "uuid-ossp";
+
+-- ---------- profiles ----------
+create table if not exists public.profiles (
+  id uuid primary key references auth.users(id) on delete cascade,
+  email text not null,
+  display_name text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.profiles enable row level security;
+
+drop policy if exists "profiles_select_own" on public.profiles;
+create policy "profiles_select_own" on public.profiles
+  for select using (auth.uid() = id);
+
+drop policy if exists "profiles_insert_own" on public.profiles;
+create policy "profiles_insert_own" on public.profiles
+  for insert with check (auth.uid() = id);
+
+drop policy if exists "profiles_update_own" on public.profiles;
+create policy "profiles_update_own" on public.profiles
+  for update using (auth.uid() = id);
+
+-- ---------- preferences ----------
+create table if not exists public.preferences (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  preferred_platform text not null default 'chatgpt',
+  default_instruction_suffix text not null default '',
+  favorite_domains text[] not null default '{}',
+  clarification_mode text not null default 'auto'
+    check (clarification_mode in ('auto', 'always', 'never')),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.preferences enable row level security;
+
+drop policy if exists "preferences_select_own" on public.preferences;
+create policy "preferences_select_own" on public.preferences
+  for select using (auth.uid() = user_id);
+
+drop policy if exists "preferences_insert_own" on public.preferences;
+create policy "preferences_insert_own" on public.preferences
+  for insert with check (auth.uid() = user_id);
+
+drop policy if exists "preferences_update_own" on public.preferences;
+create policy "preferences_update_own" on public.preferences
+  for update using (auth.uid() = user_id);
+
+drop policy if exists "preferences_delete_own" on public.preferences;
+create policy "preferences_delete_own" on public.preferences
+  for delete using (auth.uid() = user_id);
+
+-- ---------- history ----------
+create table if not exists public.history (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  user_input text not null,
+  generated_prompt text not null,
+  platform text not null,
+  favorite boolean not null default false,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists history_user_created_idx
+  on public.history (user_id, created_at desc);
+
+alter table public.history enable row level security;
+
+drop policy if exists "history_select_own" on public.history;
+create policy "history_select_own" on public.history
+  for select using (auth.uid() = user_id);
+
+drop policy if exists "history_insert_own" on public.history;
+create policy "history_insert_own" on public.history
+  for insert with check (auth.uid() = user_id);
+
+drop policy if exists "history_update_own" on public.history;
+create policy "history_update_own" on public.history
+  for update using (auth.uid() = user_id);
+
+drop policy if exists "history_delete_own" on public.history;
+create policy "history_delete_own" on public.history
+  for delete using (auth.uid() = user_id);
+
+-- ---------- feedback ----------
+create table if not exists public.feedback (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  rating text not null check (rating in ('up', 'down')),
+  comment text,
+  platform text not null,
+  domain text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists feedback_user_created_idx
+  on public.feedback (user_id, created_at desc);
+
+alter table public.feedback enable row level security;
+
+drop policy if exists "feedback_select_own" on public.feedback;
+create policy "feedback_select_own" on public.feedback
+  for select using (auth.uid() = user_id);
+
+drop policy if exists "feedback_insert_own" on public.feedback;
+create policy "feedback_insert_own" on public.feedback
+  for insert with check (auth.uid() = user_id);
+
+-- ---------- auto-create profile on signup ----------
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.profiles (id, email, display_name)
+  values (
+    new.id,
+    new.email,
+    coalesce(
+      new.raw_user_meta_data ->> 'full_name',
+      new.raw_user_meta_data ->> 'name',
+      split_part(new.email, '@', 1)
+    )
+  )
+  on conflict (id) do nothing;
+  return new;
+end;
+$$;
+
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute function public.handle_new_user();


### PR DESCRIPTION
Introduces Supabase-backed authentication as the foundation for cloud sync and future Phase-2 features (#7/#8-upgrade/#9/#10). Ships the client, store, UI surface, and SQL schema; defers the actual history/preferences/feedback cloud migration to a follow-up PR so this change stays reviewable and can merge before real users are flipped on.

What's new
- src/lib/supabase.ts: singleton @supabase/supabase-js browser client with graceful degradation when env vars are missing (`isSupabaseConfigured` flag gates every use site).
- src/stores/authStore.ts: Zustand store wrapping session state, Google OAuth, email/password sign-in + sign-up, sign-out, modal controls. Subscribes to `supabase.auth.onAuthStateChange` so external logouts reflect instantly in the UI.
- src/features/Auth/AuthModal.tsx: full login surface — Google button, email/password form, sign-up toggle, signed-in profile view, graceful "not configured" fallback pointing users at .env.example.
- src/App.tsx: initializes auth on mount; renders <AuthModal /> next to <SettingsModal />.
- src/components/Sidebar/Sidebar.tsx: adds an Account / Sign in button alongside Settings in the bottom actions.
- supabase/migrations/0001_init.sql: profiles, preferences, history, feedback tables with per-user Row-Level Security policies and an on-signup trigger that auto-creates the profile row.
- .env.example: documents VITE_SUPABASE_URL and VITE_SUPABASE_PUBLISHABLE_KEY with provisioning pointer. The optional SUPABASE_SERVICE_ROLE_KEY is noted but not used yet.
- src/stores/authStore.test.ts: 8 tests covering synchronous state transitions and the unconfigured short-circuit path.

Notes on Vite vs Next.js
- The Supabase dashboard's Next.js quickstart references @supabase/ssr
  + next/headers + NEXT_PUBLIC_* vars. This app is Vite + Vercel serverless, so we use the simpler @supabase/supabase-js client directly and VITE_* env vars. No server-side cookie middleware is needed — supabase-js auto-refreshes tokens in the browser.

Deferred to follow-up PRs
- historyStore / preferencesStore / feedbackStore cloud sync on login (writes/reads the tables created here).
- api/_lib/supabase.ts admin client (not needed until a server route performs authenticated queries or bypasses RLS).

Manual setup required before this feature is usable
- Create Supabase project, enable Google OAuth provider, add redirect URLs, and set VITE_SUPABASE_URL + VITE_SUPABASE_PUBLISHABLE_KEY in Vercel / .env.local.
- Run supabase/migrations/0001_init.sql in the Supabase SQL Editor.

Verification
- npm run lint — 4 pre-existing errors on this branch, 0 new from this change.
- npm test -- --run — 105/105 tests pass (8 new authStore tests).
- npm run build — TS strict clean; 556 KB / 164.9 KB gzipped (Supabase adds ~54 KB; still under the 200 KB gzipped PRD NFR).

https://claude.ai/code/session_011LdFZSjw8XnB1o9Vp9nFe1