### PR TITLE
feat: cloud sync on sign-in for history + preferences + feedback (Iss…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,10 @@ import { useNavigationStore } from './stores/navigationStore';
 import { useHistoryStore } from './stores/historyStore';
 import { usePreferencesStore } from './stores/preferencesStore';
 import { useAuthStore } from './stores/authStore';
+import {
+  syncStoresForUser,
+  resetLocalStoresAfterSignOut,
+} from './lib/cloudSync';
 import { useStream } from './hooks/useStream';
 import { PromptInput, PlatformSelector } from './features/PromptInput';
 import {
@@ -157,6 +161,21 @@ function App() {
 
   useEffect(() => {
     void initializeAuth();
+
+    // Cloud-sync orchestration: mirror stores when the user signs in,
+    // wipe local state when they sign out. The subscription fires on
+    // every auth transition, including the initial session restore.
+    const unsubscribe = useAuthStore.subscribe((state, prevState) => {
+      const prevUserId = prevState.user?.id ?? null;
+      const nextUserId = state.user?.id ?? null;
+      if (nextUserId && nextUserId !== prevUserId) {
+        void syncStoresForUser(nextUserId);
+      } else if (!nextUserId && prevUserId) {
+        resetLocalStoresAfterSignOut();
+      }
+    });
+
+    return unsubscribe;
   }, [initializeAuth]);
 
   return (

--- a/src/features/Feedback/FeedbackWidget.tsx
+++ b/src/features/Feedback/FeedbackWidget.tsx
@@ -1,4 +1,6 @@
 import { useFeedbackStore } from '../../stores/feedbackStore';
+import { useAuthStore } from '../../stores/authStore';
+import { supabase, isSupabaseConfigured } from '../../lib/supabase';
 import type { Rating } from '../../stores/feedbackStore';
 import styles from './FeedbackWidget.module.css';
 
@@ -20,13 +22,29 @@ export function FeedbackWidget({ platform }: FeedbackWidgetProps) {
     if (!rating) return;
     setSubmitting(true);
     try {
-      const body: Record<string, unknown> = { rating, platform };
-      if (comment.trim()) body.comment = comment.trim();
-      await fetch('/api/feedback', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      });
+      const authUser = useAuthStore.getState().user;
+
+      if (authUser && isSupabaseConfigured) {
+        // Signed in — write directly to Supabase (RLS restricts to user).
+        const { error } = await supabase.from('feedback').insert({
+          user_id: authUser.id,
+          rating,
+          comment: comment.trim() || null,
+          platform,
+        });
+        if (error) {
+          console.error('[feedback] supabase insert', error);
+        }
+      } else {
+        // Anonymous — fall back to the existing logging endpoint.
+        const body: Record<string, unknown> = { rating, platform };
+        if (comment.trim()) body.comment = comment.trim();
+        await fetch('/api/feedback', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+      }
     } catch {
       // Silently fail — feedback is non-critical
     }

--- a/src/lib/cloudSync.test.ts
+++ b/src/lib/cloudSync.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  hasCompletedInitialSync,
+  markInitialSyncComplete,
+  syncStoresForUser,
+  resetLocalStoresAfterSignOut,
+  __resetSyncTrackingForTests,
+} from './cloudSync';
+import { usePreferencesStore } from '../stores/preferencesStore';
+import { useHistoryStore } from '../stores/historyStore';
+
+describe('cloudSync', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    __resetSyncTrackingForTests();
+    usePreferencesStore.getState().resetLocal();
+    useHistoryStore.getState().resetLocal();
+  });
+
+  describe('sync tracking', () => {
+    it('reports false before marking', () => {
+      expect(hasCompletedInitialSync('user-a')).toBe(false);
+    });
+
+    it('reports true after marking', () => {
+      markInitialSyncComplete('user-a');
+      expect(hasCompletedInitialSync('user-a')).toBe(true);
+    });
+
+    it('tracks multiple users independently', () => {
+      markInitialSyncComplete('user-a');
+      expect(hasCompletedInitialSync('user-a')).toBe(true);
+      expect(hasCompletedInitialSync('user-b')).toBe(false);
+      markInitialSyncComplete('user-b');
+      expect(hasCompletedInitialSync('user-b')).toBe(true);
+    });
+
+    it('is idempotent — marking twice is a no-op', () => {
+      markInitialSyncComplete('user-a');
+      markInitialSyncComplete('user-a');
+      expect(hasCompletedInitialSync('user-a')).toBe(true);
+    });
+
+    it('ignores junk values in localStorage', () => {
+      localStorage.setItem('promptbuilder_synced_users', 'not-json');
+      expect(hasCompletedInitialSync('user-a')).toBe(false);
+    });
+  });
+
+  describe('syncStoresForUser', () => {
+    it('short-circuits when Supabase is not configured (no crash)', async () => {
+      // In test env VITE_SUPABASE_* is unset, so isSupabaseConfigured === false.
+      // This call must complete without touching any network.
+      await expect(syncStoresForUser('user-a')).resolves.toBeUndefined();
+    });
+
+    it('does not mark a user as synced when unconfigured', async () => {
+      await syncStoresForUser('user-a');
+      expect(hasCompletedInitialSync('user-a')).toBe(false);
+    });
+  });
+
+  describe('resetLocalStoresAfterSignOut', () => {
+    it('clears preferencesStore and historyStore back to defaults', () => {
+      usePreferencesStore.getState().setPreferredPlatform('claude');
+      usePreferencesStore.getState().setDefaultInstructionSuffix('hello');
+      useHistoryStore.getState().addEntry({
+        userInput: 'test input ten chars',
+        generatedPrompt: 'test prompt',
+        platform: 'claude',
+      });
+
+      expect(usePreferencesStore.getState().preferredPlatform).toBe('claude');
+      expect(useHistoryStore.getState().entries.length).toBe(1);
+
+      resetLocalStoresAfterSignOut();
+
+      expect(usePreferencesStore.getState().preferredPlatform).toBe('chatgpt');
+      expect(usePreferencesStore.getState().defaultInstructionSuffix).toBe('');
+      expect(useHistoryStore.getState().entries).toEqual([]);
+    });
+  });
+});

--- a/src/lib/cloudSync.ts
+++ b/src/lib/cloudSync.ts
@@ -1,0 +1,87 @@
+import { usePreferencesStore } from '../stores/preferencesStore';
+import { useHistoryStore } from '../stores/historyStore';
+import { isSupabaseConfigured } from './supabase';
+
+const SYNCED_USERS_KEY = 'promptbuilder_synced_users';
+
+function loadSyncedUsers(): string[] {
+  try {
+    const raw = localStorage.getItem(SYNCED_USERS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((x): x is string => typeof x === 'string');
+  } catch {
+    return [];
+  }
+}
+
+function saveSyncedUsers(ids: string[]): void {
+  try {
+    localStorage.setItem(SYNCED_USERS_KEY, JSON.stringify(ids));
+  } catch {
+    // Storage unavailable — silently fail.
+  }
+}
+
+/**
+ * Has this user already completed the first-time local→cloud migration
+ * on this browser? Used to decide whether a sign-in should upload local
+ * data (first-sync) or simply download cloud data (subsequent sign-in).
+ */
+export function hasCompletedInitialSync(userId: string): boolean {
+  return loadSyncedUsers().includes(userId);
+}
+
+export function markInitialSyncComplete(userId: string): void {
+  const ids = loadSyncedUsers();
+  if (!ids.includes(userId)) {
+    ids.push(userId);
+    saveSyncedUsers(ids);
+  }
+}
+
+/** Test hook — resets sync-tracking state. Not used in production code. */
+export function __resetSyncTrackingForTests(): void {
+  try {
+    localStorage.removeItem(SYNCED_USERS_KEY);
+  } catch {
+    // noop
+  }
+}
+
+/**
+ * Called when the user transitions from signed-out to signed-in.
+ *
+ * - First sign-in for this user on this device: upload the anonymous local
+ *   data to Supabase (local-wins on conflict), then mark this user as
+ *   synced.
+ * - Subsequent sign-ins: skip upload; only download cloud state.
+ *
+ * In both cases we finish by downloading cloud state into local, so the
+ * in-memory store is authoritative and write-throughs are consistent.
+ */
+export async function syncStoresForUser(userId: string): Promise<void> {
+  if (!isSupabaseConfigured) return;
+
+  const isFirstSync = !hasCompletedInitialSync(userId);
+
+  if (isFirstSync) {
+    await usePreferencesStore.getState().uploadLocalToCloud(userId);
+    await useHistoryStore.getState().uploadLocalToCloud(userId);
+    markInitialSyncComplete(userId);
+  }
+
+  await usePreferencesStore.getState().loadFromCloud(userId);
+  await useHistoryStore.getState().loadFromCloud(userId);
+}
+
+/**
+ * Called when the user signs out. Wipes local state so a subsequent user
+ * on a shared device doesn't inherit the previous user's data. Cloud data
+ * is untouched and will re-hydrate on next sign-in.
+ */
+export function resetLocalStoresAfterSignOut(): void {
+  usePreferencesStore.getState().resetLocal();
+  useHistoryStore.getState().resetLocal();
+}

--- a/src/stores/historyStore.test.ts
+++ b/src/stores/historyStore.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useHistoryStore } from './historyStore';
+
+describe('historyStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useHistoryStore.getState().resetLocal();
+  });
+
+  it('starts with an empty list', () => {
+    expect(useHistoryStore.getState().entries).toEqual([]);
+  });
+
+  it('addEntry prepends a new entry with an id and timestamp', () => {
+    useHistoryStore.getState().addEntry({
+      userInput: 'describe a rainy morning in tokyo',
+      generatedPrompt: 'Write a short descriptive paragraph...',
+      platform: 'claude',
+    });
+    const entries = useHistoryStore.getState().entries;
+    expect(entries.length).toBe(1);
+    expect(entries[0].userInput).toBe('describe a rainy morning in tokyo');
+    expect(entries[0].platform).toBe('claude');
+    expect(entries[0].favorite).toBe(false);
+    expect(typeof entries[0].id).toBe('string');
+    expect(entries[0].id.length).toBeGreaterThan(0);
+    expect(typeof entries[0].createdAt).toBe('number');
+  });
+
+  it('addEntry pushes newest entries to the front', () => {
+    const s = useHistoryStore.getState();
+    s.addEntry({ userInput: 'one two three four', generatedPrompt: 'a', platform: 'chatgpt' });
+    s.addEntry({ userInput: 'five six seven eight', generatedPrompt: 'b', platform: 'chatgpt' });
+    const entries = useHistoryStore.getState().entries;
+    expect(entries[0].userInput).toBe('five six seven eight');
+    expect(entries[1].userInput).toBe('one two three four');
+  });
+
+  it('removeEntry deletes by id', () => {
+    const s = useHistoryStore.getState();
+    s.addEntry({ userInput: 'one two three four', generatedPrompt: 'a', platform: 'chatgpt' });
+    const id = useHistoryStore.getState().entries[0].id;
+    s.removeEntry(id);
+    expect(useHistoryStore.getState().entries).toEqual([]);
+  });
+
+  it('toggleFavorite flips the favorite flag', () => {
+    const s = useHistoryStore.getState();
+    s.addEntry({ userInput: 'one two three four', generatedPrompt: 'a', platform: 'chatgpt' });
+    const id = useHistoryStore.getState().entries[0].id;
+    s.toggleFavorite(id);
+    expect(useHistoryStore.getState().entries[0].favorite).toBe(true);
+    s.toggleFavorite(id);
+    expect(useHistoryStore.getState().entries[0].favorite).toBe(false);
+  });
+
+  it('clearAll empties the list', () => {
+    const s = useHistoryStore.getState();
+    s.addEntry({ userInput: 'one two three four', generatedPrompt: 'a', platform: 'chatgpt' });
+    s.addEntry({ userInput: 'five six seven eight', generatedPrompt: 'b', platform: 'chatgpt' });
+    s.clearAll();
+    expect(useHistoryStore.getState().entries).toEqual([]);
+  });
+
+  it('resetLocal wipes entries without touching the cloud', () => {
+    const s = useHistoryStore.getState();
+    s.addEntry({ userInput: 'one two three four', generatedPrompt: 'a', platform: 'chatgpt' });
+    s.resetLocal();
+    expect(useHistoryStore.getState().entries).toEqual([]);
+  });
+
+  it('cloud methods are safe no-ops when Supabase is unconfigured', async () => {
+    // isSupabaseConfigured is false in the test env.
+    await expect(
+      useHistoryStore.getState().loadFromCloud('user-a'),
+    ).resolves.toBeUndefined();
+    await expect(
+      useHistoryStore.getState().uploadLocalToCloud('user-a'),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/stores/historyStore.ts
+++ b/src/stores/historyStore.ts
@@ -1,4 +1,6 @@
 import { create } from 'zustand';
+import { supabase, isSupabaseConfigured } from '../lib/supabase';
+import { useAuthStore } from './authStore';
 
 const STORAGE_KEY = 'promptbuilder_history';
 const MAX_ENTRIES = 100;
@@ -18,6 +20,10 @@ interface HistoryState {
   removeEntry: (id: string) => void;
   toggleFavorite: (id: string) => void;
   clearAll: () => void;
+  // Cloud sync surface — no-ops when Supabase is not configured.
+  loadFromCloud: (userId: string) => Promise<void>;
+  uploadLocalToCloud: (userId: string) => Promise<void>;
+  resetLocal: () => void;
 }
 
 function loadFromStorage(): HistoryEntry[] {
@@ -40,18 +46,53 @@ function saveToStorage(entries: HistoryEntry[]): void {
   }
 }
 
-export const useHistoryStore = create<HistoryState>((set) => ({
+function getSignedInUserId(): string | null {
+  if (!isSupabaseConfigured) return null;
+  return useAuthStore.getState().user?.id ?? null;
+}
+
+function entryToRow(entry: HistoryEntry, userId: string) {
+  return {
+    id: entry.id,
+    user_id: userId,
+    user_input: entry.userInput,
+    generated_prompt: entry.generatedPrompt,
+    platform: entry.platform,
+    favorite: entry.favorite,
+    created_at: new Date(entry.createdAt).toISOString(),
+  };
+}
+
+function rowToEntry(row: {
+  id: string;
+  user_input: string;
+  generated_prompt: string;
+  platform: string;
+  favorite: boolean;
+  created_at: string;
+}): HistoryEntry {
+  return {
+    id: row.id,
+    userInput: row.user_input,
+    generatedPrompt: row.generated_prompt,
+    platform: row.platform,
+    favorite: Boolean(row.favorite),
+    createdAt: new Date(row.created_at).getTime(),
+  };
+}
+
+export const useHistoryStore = create<HistoryState>((set, get) => ({
   entries: loadFromStorage(),
 
-  addEntry: (entry) =>
-    set((state) => {
-      const newEntry: HistoryEntry = {
-        ...entry,
-        id: crypto.randomUUID(),
-        createdAt: Date.now(),
-        favorite: false,
-      };
+  addEntry: (entry) => {
+    const newEntry: HistoryEntry = {
+      ...entry,
+      id: crypto.randomUUID(),
+      createdAt: Date.now(),
+      favorite: false,
+    };
 
+    set((state) => {
       let entries = [newEntry, ...state.entries];
 
       // Enforce max 100 entries: drop oldest non-favorite when over the limit
@@ -71,26 +112,113 @@ export const useHistoryStore = create<HistoryState>((set) => ({
 
       saveToStorage(entries);
       return { entries };
-    }),
+    });
 
-  removeEntry: (id) =>
+    const userId = getSignedInUserId();
+    if (userId) {
+      void (async () => {
+        const { error } = await supabase
+          .from('history')
+          .insert(entryToRow(newEntry, userId));
+        if (error) console.error('[historyStore] addEntry', error);
+      })();
+    }
+  },
+
+  removeEntry: (id) => {
     set((state) => {
       const entries = state.entries.filter((e) => e.id !== id);
       saveToStorage(entries);
       return { entries };
-    }),
+    });
 
-  toggleFavorite: (id) =>
+    const userId = getSignedInUserId();
+    if (userId) {
+      void (async () => {
+        const { error } = await supabase
+          .from('history')
+          .delete()
+          .eq('id', id)
+          .eq('user_id', userId);
+        if (error) console.error('[historyStore] removeEntry', error);
+      })();
+    }
+  },
+
+  toggleFavorite: (id) => {
+    let nextFavorite = false;
     set((state) => {
-      const entries = state.entries.map((e) =>
-        e.id === id ? { ...e, favorite: !e.favorite } : e,
-      );
+      const entries = state.entries.map((e) => {
+        if (e.id === id) {
+          nextFavorite = !e.favorite;
+          return { ...e, favorite: nextFavorite };
+        }
+        return e;
+      });
       saveToStorage(entries);
       return { entries };
-    }),
+    });
+
+    const userId = getSignedInUserId();
+    if (userId) {
+      void (async () => {
+        const { error } = await supabase
+          .from('history')
+          .update({ favorite: nextFavorite })
+          .eq('id', id)
+          .eq('user_id', userId);
+        if (error) console.error('[historyStore] toggleFavorite', error);
+      })();
+    }
+  },
 
   clearAll: () => {
     saveToStorage([]);
-    return set({ entries: [] });
+    set({ entries: [] });
+
+    const userId = getSignedInUserId();
+    if (userId) {
+      void (async () => {
+        const { error } = await supabase
+          .from('history')
+          .delete()
+          .eq('user_id', userId);
+        if (error) console.error('[historyStore] clearAll', error);
+      })();
+    }
+  },
+
+  loadFromCloud: async (userId: string) => {
+    if (!isSupabaseConfigured) return;
+    const { data, error } = await supabase
+      .from('history')
+      .select('id, user_input, generated_prompt, platform, favorite, created_at')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+      .limit(MAX_ENTRIES);
+    if (error) {
+      console.error('[historyStore] loadFromCloud', error);
+      return;
+    }
+    const entries = (data ?? []).map(rowToEntry);
+    saveToStorage(entries);
+    set({ entries });
+  },
+
+  uploadLocalToCloud: async (userId: string) => {
+    if (!isSupabaseConfigured) return;
+    const entries = get().entries;
+    if (entries.length === 0) return;
+    const rows = entries.map((e) => entryToRow(e, userId));
+    // upsert on id — preserves local IDs and is idempotent if we retry.
+    const { error } = await supabase
+      .from('history')
+      .upsert(rows, { onConflict: 'id' });
+    if (error) console.error('[historyStore] uploadLocalToCloud', error);
+  },
+
+  resetLocal: () => {
+    saveToStorage([]);
+    set({ entries: [] });
   },
 }));

--- a/src/stores/preferencesStore.test.ts
+++ b/src/stores/preferencesStore.test.ts
@@ -88,4 +88,23 @@ describe('preferencesStore', () => {
     expect(after.clarificationMode).toBe('auto');
   });
 
+  it('resetLocal wipes state and storage without touching cloud', () => {
+    const s = usePreferencesStore.getState();
+    s.setPreferredPlatform('claude');
+    s.setDefaultInstructionSuffix('hi');
+    s.resetLocal();
+    const after = usePreferencesStore.getState();
+    expect(after.preferredPlatform).toBe('chatgpt');
+    expect(after.defaultInstructionSuffix).toBe('');
+    expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+  });
+
+  it('cloud methods are safe no-ops when Supabase is unconfigured', async () => {
+    await expect(
+      usePreferencesStore.getState().loadFromCloud('user-a'),
+    ).resolves.toBeUndefined();
+    await expect(
+      usePreferencesStore.getState().uploadLocalToCloud('user-a'),
+    ).resolves.toBeUndefined();
+  });
 });

--- a/src/stores/preferencesStore.ts
+++ b/src/stores/preferencesStore.ts
@@ -1,6 +1,8 @@
 import { create } from 'zustand';
 import type { Platform } from '../types/platform';
 import { DEFAULT_PLATFORM } from '../constants/platforms';
+import { supabase, isSupabaseConfigured } from '../lib/supabase';
+import { useAuthStore } from './authStore';
 
 const STORAGE_KEY = 'promptbuilder_preferences';
 export const INSTRUCTION_SUFFIX_MAX_LENGTH = 500;
@@ -50,6 +52,10 @@ export interface PreferencesState extends StoredPreferences {
   toggleFavoriteDomain: (domain: string) => void;
   setClarificationMode: (mode: ClarificationMode) => void;
   resetPreferences: () => void;
+  // Cloud sync surface — no-ops when Supabase is not configured.
+  loadFromCloud: (userId: string) => Promise<void>;
+  uploadLocalToCloud: (userId: string) => Promise<void>;
+  resetLocal: () => void;
 }
 
 function loadFromStorage(): StoredPreferences {
@@ -91,20 +97,42 @@ function saveToStorage(prefs: StoredPreferences): void {
   }
 }
 
+async function writeToCloud(
+  prefs: StoredPreferences,
+  userId: string,
+): Promise<void> {
+  if (!isSupabaseConfigured) return;
+  const { error } = await supabase.from('preferences').upsert(
+    {
+      user_id: userId,
+      preferred_platform: prefs.preferredPlatform,
+      default_instruction_suffix: prefs.defaultInstructionSuffix,
+      favorite_domains: prefs.favoriteDomains,
+      clarification_mode: prefs.clarificationMode,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: 'user_id' },
+  );
+  if (error) {
+    console.error('[preferencesStore] writeToCloud', error);
+  }
+}
+
 export const usePreferencesStore = create<PreferencesState>((set, get) => {
   const persist = () => {
-    const {
-      preferredPlatform,
-      defaultInstructionSuffix,
-      favoriteDomains,
-      clarificationMode,
-    } = get();
-    saveToStorage({
-      preferredPlatform,
-      defaultInstructionSuffix,
-      favoriteDomains,
-      clarificationMode,
-    });
+    const snapshot: StoredPreferences = {
+      preferredPlatform: get().preferredPlatform,
+      defaultInstructionSuffix: get().defaultInstructionSuffix,
+      favoriteDomains: get().favoriteDomains,
+      clarificationMode: get().clarificationMode,
+    };
+    saveToStorage(snapshot);
+    // Write-through to cloud when a user is signed in. Fire-and-forget;
+    // errors are logged but never break the local update.
+    const userId = useAuthStore.getState().user?.id;
+    if (userId) {
+      void writeToCloud(snapshot, userId);
+    }
   };
 
   return {
@@ -138,6 +166,64 @@ export const usePreferencesStore = create<PreferencesState>((set, get) => {
     resetPreferences: () => {
       set({ ...DEFAULTS });
       persist();
+    },
+
+    loadFromCloud: async (userId: string) => {
+      if (!isSupabaseConfigured) return;
+      const { data, error } = await supabase
+        .from('preferences')
+        .select(
+          'preferred_platform, default_instruction_suffix, favorite_domains, clarification_mode',
+        )
+        .eq('user_id', userId)
+        .maybeSingle();
+      if (error) {
+        console.error('[preferencesStore] loadFromCloud', error);
+        return;
+      }
+      if (!data) return; // No cloud row yet — local stays as-is.
+      const loaded: StoredPreferences = {
+        preferredPlatform: PLATFORMS.includes(data.preferred_platform as Platform)
+          ? (data.preferred_platform as Platform)
+          : DEFAULTS.preferredPlatform,
+        defaultInstructionSuffix:
+          typeof data.default_instruction_suffix === 'string'
+            ? data.default_instruction_suffix.slice(
+                0,
+                INSTRUCTION_SUFFIX_MAX_LENGTH,
+              )
+            : DEFAULTS.defaultInstructionSuffix,
+        favoriteDomains: Array.isArray(data.favorite_domains)
+          ? data.favorite_domains.filter(
+              (d: unknown): d is string => typeof d === 'string',
+            )
+          : DEFAULTS.favoriteDomains,
+        clarificationMode: MODES.includes(
+          data.clarification_mode as ClarificationMode,
+        )
+          ? (data.clarification_mode as ClarificationMode)
+          : DEFAULTS.clarificationMode,
+      };
+      set(loaded);
+      saveToStorage(loaded);
+    },
+
+    uploadLocalToCloud: async (userId: string) => {
+      if (!isSupabaseConfigured) return;
+      const snapshot: StoredPreferences = {
+        preferredPlatform: get().preferredPlatform,
+        defaultInstructionSuffix: get().defaultInstructionSuffix,
+        favoriteDomains: get().favoriteDomains,
+        clarificationMode: get().clarificationMode,
+      };
+      await writeToCloud(snapshot, userId);
+    },
+
+    resetLocal: () => {
+      // Explicitly does NOT call persist() — used on sign-out to clear the
+      // browser without touching the cloud or writing a defaults row.
+      saveToStorage(DEFAULTS);
+      set({ ...DEFAULTS });
     },
   };
 });


### PR DESCRIPTION
…ue #6 pt 2)

Completes the second half of Issue #6 by wiring historyStore, preferencesStore, and feedback submissions through to the Supabase tables created in #12. Anonymous behaviour is preserved — every cloud path is gated on `isSupabaseConfigured` and the presence of a signed-in user, so the app still works end-to-end when env vars are unset.

Merge strategy (per approved plan)
- First sign-in on a device: upload local data to Supabase (local-wins on conflict via upsert), mark the user as synced, then download the resulting cloud state so local and cloud agree.
- Subsequent sign-ins: skip the upload, just download cloud → local. Cloud is the source of truth while signed in; every mutator writes through to cloud on top of localStorage.
- Sign-out: wipe local state for preferences + history so the next user on a shared device starts clean. Cloud is untouched and re-hydrates on the next sign-in.

What's new
- src/lib/cloudSync.ts: per-user sync tracking (`promptbuilder_synced_users` localStorage key), `syncStoresForUser(userId)` orchestrator, and `resetLocalStoresAfterSignOut()`. Single place that knows the upload-then-download sequencing.
- src/stores/preferencesStore.ts: new `loadFromCloud`, `uploadLocalToCloud`, `resetLocal` methods. All existing setters now write-through to Supabase.preferences via upsert when a user is signed in.
- src/stores/historyStore.ts: same surface (`loadFromCloud`/`uploadLocalToCloud`/`resetLocal`). addEntry, removeEntry, toggleFavorite, clearAll all mirror to Supabase.history. Local IDs are preserved across the sync boundary (upsert on id) so entries don't duplicate on retry.
- src/features/Feedback/FeedbackWidget.tsx: when signed in, insert directly into Supabase.feedback (RLS scopes the row to the user). Anonymous users continue to hit the existing /api/feedback endpoint so the behaviour for logged-out users is unchanged.
- src/App.tsx: subscribes to useAuthStore transitions in the existing bootstrap effect. On user-id change it calls syncStoresForUser; on sign-out it calls resetLocalStoresAfterSignOut. Unsubscribes on unmount.

Tests
- src/lib/cloudSync.test.ts: 8 tests covering sync-tracking helpers, the "unconfigured Supabase" short-circuit, and the sign-out reset wiping both stores.
- src/stores/historyStore.test.ts: 8 tests covering local CRUD, resetLocal, and the unconfigured-cloud no-op path (the store had no prior tests).
- src/stores/preferencesStore.test.ts: +2 tests for resetLocal and the unconfigured-cloud no-op path.

Notes
- Cloud knowledge is isolated to `src/lib/supabase.ts`, `src/lib/cloudSync.ts`, and the stores themselves. No new API routes, no Vercel changes.
- feedbackStore itself is unchanged — it holds ephemeral per-generation UI state. Persistence happens in FeedbackWidget at submit time.
- The SUPABASE_SERVICE_ROLE_KEY is still not needed and remains optional in .env.example.

Verification
- npm run lint — 4 pre-existing errors, 0 new.
- npm test -- --run — 123/123 tests pass (+18 new).
- npm run build — TS strict clean; 560.54 KB / 165.87 KB gzipped (+0.97 KB gzipped vs #12 baseline; still under the 200 KB NFR).

https://claude.ai/code/session_011LdFZSjw8XnB1o9Vp9nFe1