### PR TITLE
feat: richer feedback — stars + categories + domain (Issue #10)

### DIFF
--- a/api/feedback.ts
+++ b/api/feedback.ts
@@ -1,10 +1,15 @@
 import { z } from 'zod';
 import { checkOrigin } from './_lib/cors.js';
 
+const FEEDBACK_CATEGORIES = ['accuracy', 'usefulness', 'clarity', 'tone'] as const;
+
 const feedbackSchema = z.object({
   rating: z.enum(['up', 'down']),
   comment: z.string().max(500).optional(),
   platform: z.enum(['chatgpt', 'claude', 'gemini', 'grok', 'perplexity']),
+  stars: z.number().int().min(1).max(5).optional(),
+  categories: z.array(z.enum(FEEDBACK_CATEGORIES)).max(4).optional(),
+  domain: z.string().max(64).optional(),
 });
 
 function errorResponse(code: string, message: string, status: number) {

--- a/src/features/Auth/AuthModal.tsx
+++ b/src/features/Auth/AuthModal.tsx
@@ -120,11 +120,21 @@ export function AuthModal() {
 
         {!isConfigured && (
           <div className={styles.notConfigured}>
-            Sign-in is unavailable because Supabase is not configured. Copy
-            <code>.env.example</code> to <code>.env.local</code> and add your{' '}
-            <code>VITE_SUPABASE_URL</code> and{' '}
-            <code>VITE_SUPABASE_PUBLISHABLE_KEY</code>, then restart the dev
-            server.
+            {typeof window !== 'undefined' &&
+            (window.location.hostname === 'localhost' ||
+              window.location.hostname === '127.0.0.1') ? (
+              <>
+                Sign-in is unavailable because Supabase is not configured.
+                Copy <code>.env.example</code> to <code>.env.local</code>, add
+                your <code>VITE_SUPABASE_URL</code> and{' '}
+                <code>VITE_SUPABASE_PUBLISHABLE_KEY</code>, then restart{' '}
+                <code>npm run dev</code>.
+              </>
+            ) : (
+              <>
+                Sign-in is temporarily unavailable. Please try again later.
+              </>
+            )}
           </div>
         )}
 

--- a/src/features/Feedback/FeedbackWidget.module.css
+++ b/src/features/Feedback/FeedbackWidget.module.css
@@ -132,3 +132,104 @@
   font-size: var(--font-size-md);
   color: var(--sage);
 }
+
+/* Star rating row */
+.starFieldset {
+  margin: var(--space-md) 0 var(--space-sm);
+  padding: 0;
+  border: 0;
+}
+
+.starLegend,
+.categoryLegend {
+  font-family: var(--font-body);
+  font-size: var(--font-size-eyebrow);
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+  padding: 0;
+  margin-bottom: var(--space-xs);
+}
+
+.starRow {
+  display: flex;
+  gap: var(--space-xs);
+}
+
+.starButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: var(--min-tap-target);
+  min-width: var(--min-tap-target);
+  font-size: 1.5rem;
+  line-height: 1;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  color: var(--ink-muted);
+  cursor: pointer;
+  transition:
+    color var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.starButton:hover:not(:disabled) {
+  color: var(--accent);
+  transform: scale(1.05);
+}
+
+.starSelected {
+  color: var(--accent);
+}
+
+.starButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Categories & domain chip rows */
+.categoryFieldset {
+  margin: var(--space-md) 0 var(--space-sm);
+  padding: 0;
+  border: 0;
+}
+
+.chipRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+.chip {
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--ink-muted);
+  background: var(--paper-raised);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius-sm);
+  padding: 0.375rem 0.75rem;
+  cursor: pointer;
+  transition:
+    color var(--transition-fast),
+    border-color var(--transition-fast),
+    background var(--transition-fast);
+}
+
+.chip:hover:not(:disabled) {
+  color: var(--ink);
+  border-color: var(--ink-faint);
+}
+
+.chipActive {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-faint);
+}
+
+.chip:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/src/features/Feedback/FeedbackWidget.test.tsx
+++ b/src/features/Feedback/FeedbackWidget.test.tsx
@@ -81,4 +81,49 @@ describe('FeedbackWidget', () => {
       }),
     });
   });
+
+  it('renders star selector, category chips and domain chips after rating', async () => {
+    const user = userEvent.setup();
+    render(<FeedbackWidget platform="chatgpt" />);
+    await user.click(screen.getByRole('button', { name: 'Thumbs up' }));
+
+    // 5 stars
+    expect(screen.getByRole('button', { name: '1 star' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '5 stars' })).toBeInTheDocument();
+
+    // 4 category chips
+    expect(screen.getByRole('button', { name: 'Accuracy' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Usefulness' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Clarity' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Tone' })).toBeInTheDocument();
+
+    // Domain chip row (falls back to the 8 AVAILABLE_DOMAINS when the user
+    // has no favorites set).
+    expect(screen.getByRole('button', { name: 'Technical' })).toBeInTheDocument();
+  });
+
+  it('sends stars, categories, and domain to /api/feedback', async () => {
+    const user = userEvent.setup();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ success: true })),
+    );
+    render(<FeedbackWidget platform="claude" />);
+    await user.click(screen.getByRole('button', { name: 'Thumbs up' }));
+    await user.click(screen.getByRole('button', { name: '4 stars' }));
+    await user.click(screen.getByRole('button', { name: 'Accuracy' }));
+    await user.click(screen.getByRole('button', { name: 'Clarity' }));
+    await user.click(screen.getByRole('button', { name: 'Technical' }));
+    await user.click(screen.getByText('Submit Feedback'));
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [, init] = fetchSpy.mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body).toEqual({
+      rating: 'up',
+      platform: 'claude',
+      stars: 4,
+      categories: ['accuracy', 'clarity'],
+      domain: 'Technical',
+    });
+  });
 });

--- a/src/features/Feedback/FeedbackWidget.tsx
+++ b/src/features/Feedback/FeedbackWidget.tsx
@@ -1,36 +1,60 @@
-import { useFeedbackStore } from '../../stores/feedbackStore';
+import { useFeedbackStore, FEEDBACK_CATEGORIES } from '../../stores/feedbackStore';
+import type { Rating, FeedbackCategory } from '../../stores/feedbackStore';
 import { useAuthStore } from '../../stores/authStore';
+import { usePreferencesStore, AVAILABLE_DOMAINS } from '../../stores/preferencesStore';
 import { supabase, isSupabaseConfigured } from '../../lib/supabase';
-import type { Rating } from '../../stores/feedbackStore';
 import styles from './FeedbackWidget.module.css';
 
 interface FeedbackWidgetProps {
   platform: string;
 }
 
+const CATEGORY_LABELS: Record<FeedbackCategory, string> = {
+  accuracy: 'Accuracy',
+  usefulness: 'Usefulness',
+  clarity: 'Clarity',
+  tone: 'Tone',
+};
+
 export function FeedbackWidget({ platform }: FeedbackWidgetProps) {
   const rating = useFeedbackStore((s) => s.rating);
+  const stars = useFeedbackStore((s) => s.stars);
+  const categories = useFeedbackStore((s) => s.categories);
+  const domain = useFeedbackStore((s) => s.domain);
   const comment = useFeedbackStore((s) => s.comment);
   const isSubmitted = useFeedbackStore((s) => s.isSubmitted);
   const isSubmitting = useFeedbackStore((s) => s.isSubmitting);
   const setRating = useFeedbackStore((s) => s.setRating);
+  const setStars = useFeedbackStore((s) => s.setStars);
+  const toggleCategory = useFeedbackStore((s) => s.toggleCategory);
+  const setDomain = useFeedbackStore((s) => s.setDomain);
   const setComment = useFeedbackStore((s) => s.setComment);
   const setSubmitting = useFeedbackStore((s) => s.setSubmitting);
   const setSubmitted = useFeedbackStore((s) => s.setSubmitted);
+
+  // Surface the user's favorite domains first if they have any, otherwise
+  // fall back to the full list so first-time users still have choices.
+  const favoriteDomains = usePreferencesStore((s) => s.favoriteDomains);
+  const domainOptions: readonly string[] =
+    favoriteDomains.length > 0 ? favoriteDomains : AVAILABLE_DOMAINS;
 
   const handleSubmit = async () => {
     if (!rating) return;
     setSubmitting(true);
     try {
       const authUser = useAuthStore.getState().user;
+      const trimmedComment = comment.trim() || null;
 
       if (authUser && isSupabaseConfigured) {
         // Signed in — write directly to Supabase (RLS restricts to user).
         const { error } = await supabase.from('feedback').insert({
           user_id: authUser.id,
           rating,
-          comment: comment.trim() || null,
+          comment: trimmedComment,
           platform,
+          stars,
+          categories,
+          domain,
         });
         if (error) {
           console.error('[feedback] supabase insert', error);
@@ -38,7 +62,10 @@ export function FeedbackWidget({ platform }: FeedbackWidgetProps) {
       } else {
         // Anonymous — fall back to the existing logging endpoint.
         const body: Record<string, unknown> = { rating, platform };
-        if (comment.trim()) body.comment = comment.trim();
+        if (trimmedComment) body.comment = trimmedComment;
+        if (stars != null) body.stars = stars;
+        if (categories.length > 0) body.categories = categories;
+        if (domain) body.domain = domain;
         await fetch('/api/feedback', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -81,6 +108,75 @@ export function FeedbackWidget({ platform }: FeedbackWidgetProps) {
       </div>
       {rating && (
         <>
+          <fieldset className={styles.starFieldset}>
+            <legend className={styles.starLegend}>Rate it</legend>
+            <div
+              className={styles.starRow}
+              role="radiogroup"
+              aria-label="Star rating"
+            >
+              {[1, 2, 3, 4, 5].map((value) => {
+                const selected = stars !== null && value <= stars;
+                return (
+                  <button
+                    key={value}
+                    type="button"
+                    className={`${styles.starButton} ${selected ? styles.starSelected : ''}`}
+                    onClick={() => setStars(stars === value ? null : value)}
+                    aria-label={`${value} star${value === 1 ? '' : 's'}`}
+                    aria-pressed={stars === value}
+                    disabled={isSubmitting}
+                  >
+                    {selected ? '\u2605' : '\u2606'}
+                  </button>
+                );
+              })}
+            </div>
+          </fieldset>
+
+          <fieldset className={styles.categoryFieldset}>
+            <legend className={styles.categoryLegend}>
+              What about it? (optional)
+            </legend>
+            <div className={styles.chipRow}>
+              {FEEDBACK_CATEGORIES.map((cat) => {
+                const active = categories.includes(cat);
+                return (
+                  <button
+                    key={cat}
+                    type="button"
+                    className={`${styles.chip} ${active ? styles.chipActive : ''}`}
+                    onClick={() => toggleCategory(cat)}
+                    aria-pressed={active}
+                    disabled={isSubmitting}
+                  >
+                    {CATEGORY_LABELS[cat]}
+                  </button>
+                );
+              })}
+            </div>
+          </fieldset>
+
+          <fieldset className={styles.categoryFieldset}>
+            <legend className={styles.categoryLegend}>
+              Domain (optional)
+            </legend>
+            <div className={styles.chipRow}>
+              {domainOptions.map((d) => (
+                <button
+                  key={d}
+                  type="button"
+                  className={`${styles.chip} ${domain === d ? styles.chipActive : ''}`}
+                  onClick={() => setDomain(domain === d ? null : d)}
+                  aria-pressed={domain === d}
+                  disabled={isSubmitting}
+                >
+                  {d}
+                </button>
+              ))}
+            </div>
+          </fieldset>
+
           <label htmlFor="feedback-comment" className={styles.commentLabel}>
             Tell us more (optional)
           </label>

--- a/src/stores/feedbackStore.test.ts
+++ b/src/stores/feedbackStore.test.ts
@@ -9,6 +9,9 @@ describe('feedbackStore', () => {
   it('has correct initial state', () => {
     const state = useFeedbackStore.getState();
     expect(state.rating).toBeNull();
+    expect(state.stars).toBeNull();
+    expect(state.categories).toEqual([]);
+    expect(state.domain).toBeNull();
     expect(state.comment).toBe('');
     expect(state.isSubmitted).toBe(false);
     expect(state.isSubmitting).toBe(false);
@@ -17,6 +20,33 @@ describe('feedbackStore', () => {
   it('setRating stores rating', () => {
     useFeedbackStore.getState().setRating('up');
     expect(useFeedbackStore.getState().rating).toBe('up');
+  });
+
+  it('setStars stores a 1-5 rating', () => {
+    useFeedbackStore.getState().setStars(4);
+    expect(useFeedbackStore.getState().stars).toBe(4);
+    useFeedbackStore.getState().setStars(null);
+    expect(useFeedbackStore.getState().stars).toBeNull();
+  });
+
+  it('toggleCategory adds and removes categories', () => {
+    const s = useFeedbackStore.getState();
+    s.toggleCategory('accuracy');
+    expect(useFeedbackStore.getState().categories).toEqual(['accuracy']);
+    s.toggleCategory('clarity');
+    expect(useFeedbackStore.getState().categories).toEqual([
+      'accuracy',
+      'clarity',
+    ]);
+    s.toggleCategory('accuracy');
+    expect(useFeedbackStore.getState().categories).toEqual(['clarity']);
+  });
+
+  it('setDomain stores the selected domain', () => {
+    useFeedbackStore.getState().setDomain('Technical');
+    expect(useFeedbackStore.getState().domain).toBe('Technical');
+    useFeedbackStore.getState().setDomain(null);
+    expect(useFeedbackStore.getState().domain).toBeNull();
   });
 
   it('setComment stores comment', () => {
@@ -32,13 +62,20 @@ describe('feedbackStore', () => {
     expect(state.isSubmitting).toBe(false);
   });
 
-  it('resetFeedback clears all state', () => {
-    useFeedbackStore.getState().setRating('down');
-    useFeedbackStore.getState().setComment('Not helpful');
-    useFeedbackStore.getState().setSubmitted();
-    useFeedbackStore.getState().resetFeedback();
+  it('resetFeedback clears all state including new fields', () => {
+    const s = useFeedbackStore.getState();
+    s.setRating('down');
+    s.setStars(2);
+    s.toggleCategory('tone');
+    s.setDomain('Sales');
+    s.setComment('Not helpful');
+    s.setSubmitted();
+    s.resetFeedback();
     const state = useFeedbackStore.getState();
     expect(state.rating).toBeNull();
+    expect(state.stars).toBeNull();
+    expect(state.categories).toEqual([]);
+    expect(state.domain).toBeNull();
     expect(state.comment).toBe('');
     expect(state.isSubmitted).toBe(false);
     expect(state.isSubmitting).toBe(false);

--- a/src/stores/feedbackStore.ts
+++ b/src/stores/feedbackStore.ts
@@ -2,32 +2,62 @@ import { create } from 'zustand';
 
 export type Rating = 'up' | 'down';
 
+export const FEEDBACK_CATEGORIES = [
+  'accuracy',
+  'usefulness',
+  'clarity',
+  'tone',
+] as const;
+export type FeedbackCategory = (typeof FEEDBACK_CATEGORIES)[number];
+
 interface FeedbackState {
   rating: Rating | null;
+  stars: number | null;
+  categories: FeedbackCategory[];
+  domain: string | null;
   comment: string;
   isSubmitted: boolean;
   isSubmitting: boolean;
 
   setRating: (rating: Rating) => void;
+  setStars: (stars: number | null) => void;
+  toggleCategory: (category: FeedbackCategory) => void;
+  setDomain: (domain: string | null) => void;
   setComment: (comment: string) => void;
   setSubmitting: (isSubmitting: boolean) => void;
   setSubmitted: () => void;
   resetFeedback: () => void;
 }
 
-export const useFeedbackStore = create<FeedbackState>((set) => ({
+export const useFeedbackStore = create<FeedbackState>((set, get) => ({
   rating: null,
+  stars: null,
+  categories: [],
+  domain: null,
   comment: '',
   isSubmitted: false,
   isSubmitting: false,
 
   setRating: (rating) => set({ rating }),
+  setStars: (stars) => set({ stars }),
+  toggleCategory: (category) => {
+    const current = get().categories;
+    set({
+      categories: current.includes(category)
+        ? current.filter((c) => c !== category)
+        : [...current, category],
+    });
+  },
+  setDomain: (domain) => set({ domain }),
   setComment: (comment) => set({ comment }),
   setSubmitting: (isSubmitting) => set({ isSubmitting }),
   setSubmitted: () => set({ isSubmitted: true, isSubmitting: false }),
   resetFeedback: () =>
     set({
       rating: null,
+      stars: null,
+      categories: [],
+      domain: null,
       comment: '',
       isSubmitted: false,
       isSubmitting: false,

--- a/supabase/migrations/0002_feedback_categories.sql
+++ b/supabase/migrations/0002_feedback_categories.sql
@@ -1,0 +1,21 @@
+-- PromptBuilder — Issue #10 schema extension for richer feedback.
+--
+-- Run this once against your Supabase project via the SQL Editor:
+--   Supabase Dashboard → SQL Editor → New query → paste → Run
+--
+-- Extends public.feedback (created in 0001_init.sql) with:
+--   stars       — optional 1–5 star rating alongside the existing thumbs
+--   categories  — optional multi-select of {accuracy,usefulness,clarity,tone}
+--
+-- `domain` already exists from 0001 and is reused (no change needed).
+-- RLS policies from 0001 still cover the new columns (they are column-level
+-- additions on an already-protected table).
+
+alter table public.feedback
+  add column if not exists stars smallint check (stars between 1 and 5),
+  add column if not exists categories text[] not null default '{}';
+
+-- Optional: a GIN index on categories to make "which prompts had accuracy
+-- issues" queries fast once the analytics dashboard (#9) lands.
+create index if not exists feedback_categories_idx
+  on public.feedback using gin (categories);


### PR DESCRIPTION
Extends the feedback surface with a 1–5 star rating, four category checkboxes (accuracy/usefulness/clarity/tone), and a domain chip row, backed by a schema migration that adds the corresponding columns to public.feedback. The admin dashboard view is intentionally deferred to Issue #9.

Schema
- supabase/migrations/0002_feedback_categories.sql: adds stars smallint (1–5 check constraint) and categories text[] (default '{}') to public.feedback. The domain column already exists from 0001. A GIN index on categories prepares the table for the analytics queries #9 will need.

Store + UI
- src/stores/feedbackStore.ts: adds stars, categories (multi-select of FEEDBACK_CATEGORIES constant), and domain to the in-memory state, plus setters and resetFeedback coverage.
- src/features/Feedback/FeedbackWidget.tsx: renders a 5-star toggle row, 4 category chips, and a domain chip row (defaults to the user's favorite domains from preferencesStore, falling back to the full AVAILABLE_DOMAINS list if they have none set). On submit: writes directly to Supabase.feedback when signed in, otherwise POSTs to the existing /api/feedback endpoint with the new optional fields.
- src/features/Feedback/FeedbackWidget.module.css: adds star / chip styles that match the existing visual language.

API
- api/feedback.ts: feedbackSchema accepts stars (int 1-5), categories (enum array, max 4), and domain (string max 64), all optional for back-compat with anonymous clients.

Prod copy fix (bundled per plan)
- src/features/Auth/AuthModal.tsx: the "Supabase not configured" fallback now branches on hostname. On localhost it keeps the developer-focused "copy .env.example → .env.local, restart dev server" instructions; on production hostnames it shows "Sign-in is temporarily unavailable. Please try again later." — no more stray .env.local references leaking to end users.

Tests (+5 net)
- src/stores/feedbackStore.test.ts: coverage for setStars, toggleCategory, setDomain, and the extended resetFeedback path.
- src/features/Feedback/FeedbackWidget.test.tsx: renders all the new controls, submits stars/categories/domain to /api/feedback, and preserves the existing thumbs-only submission path.

Verification
- npm run lint — 4 pre-existing errors, 0 new.
- npm test -- --run — 128/128 tests pass (+5 new vs PR #13 baseline).
- npm run build — TS strict clean; 563 KB / 166.55 KB gzipped (+0.68 KB vs #13, still under the 200 KB NFR).

Manual setup required after merge
- Run supabase/migrations/0002_feedback_categories.sql in the Supabase SQL Editor. Until that runs, signed-in feedback submissions that include stars or categories will 400 against the schema.

https://claude.ai/code/session_011LdFZSjw8XnB1o9Vp9nFe1